### PR TITLE
Fix board header overflow on smaller screens

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -384,6 +384,28 @@ header h1 {
         align-items: center;
     }
 
+    .board-header {
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+
+    .board-name {
+        flex-basis: 100%;
+        text-align: center;
+        font-size: 1.5rem;
+    }
+
+    .back-btn {
+        flex: 1;
+        min-width: 120px;
+    }
+
+    .rename-board-btn,
+    .delete-board-btn {
+        flex: 1;
+        min-width: 100px;
+    }
+
     .add-card-section {
         flex-direction: column;
         align-items: stretch;


### PR DESCRIPTION
Fixes #5

Added responsive CSS to make the board header wrap elements on smaller screens:
- Board name takes full width and is centered
- Back button and action buttons wrap to a second row
- All buttons distribute space evenly with minimum widths

This prevents the overflow issue where the "back to boards" title row overflowed on smaller screens.

Generated with [Claude Code](https://claude.ai/code)